### PR TITLE
Changed HTTP POST to PUT

### DIFF
--- a/WLED.groovy
+++ b/WLED.groovy
@@ -353,7 +353,7 @@ def sendEthernetPost(path, body) {
         ]
 
         try {            
-            asynchttpPost(null, params)
+            asynchttpPut(null, params)
         } catch (e) {
             log.error "something went wrong: $e"
         }


### PR DESCRIPTION
POST replaces the segment resetting some items to default values.  PUT just updates the specified values on the segment.  Posting to turn on the segment was causing the segment to be replaced and my segment length was getting reset to 300.  Switching to PUT just turns on the existing segment.